### PR TITLE
[UPDATE] 관리자 페이지 반응성 개선

### DIFF
--- a/src/pages/Admin/PointEvent/index.jsx
+++ b/src/pages/Admin/PointEvent/index.jsx
@@ -93,8 +93,10 @@ function PointEvent() {
             <DateWrapper>시작 시간</DateWrapper>
             <DateWrapper>종료 시간</DateWrapper>
           </TextWrapper>
-          <EventDescription>이벤트 설명</EventDescription>
-          <Value>%</Value>
+          <TextWrapper>
+            <EventDescription>이벤트 설명</EventDescription>
+            <Value>%</Value>
+          </TextWrapper>
         </Event>
         {events.map((event) => {
           return (
@@ -106,8 +108,10 @@ function PointEvent() {
                   <DateWrapper>{formatDateTime(event.startTime)}</DateWrapper>
                   <DateWrapper>{formatDateTime(event.endTime)}</DateWrapper>
                 </TextWrapper>
-                <EventDescription>{event.description}</EventDescription>
-                <Value>x{event.percentage}</Value>
+                <TextWrapper>
+                  <EventDescription>{event.description}</EventDescription>
+                  <Value>x{event.percentage}</Value>
+                </TextWrapper>
               </Event>
             </div>
           );

--- a/src/pages/Admin/PointEvent/style.jsx
+++ b/src/pages/Admin/PointEvent/style.jsx
@@ -60,6 +60,11 @@ export const InputWrapper = styled.div`
 
 export const TextWrapper = styled.div`
   display: flex;
+  margin-top: 5px;
+  width: 100%;
+  @media all and (min-width: 700px) {
+    justify-content: space-between;
+  }
 `;
 
 export const EventWrapper = styled.div`
@@ -73,42 +78,63 @@ export const EventWrapper = styled.div`
 
 export const Event = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
-  margin-bottom: 25px;
+  //grid-template-columns: 1fr 1fr 2fr 2fr 2fr 1fr;
+
+  margin-bottom: 20px;
   width: 100%;
   height: auto;
+  @media all and (min-width: 700px) {
+    flex-direction: row;
+    align-items: center;
+  }
+  @media all and (max-width: 700px) {
+    border-top: 1px solid lightgray;
+  }
 `;
 
 export const EventDescription = styled.div`
-  flex-grow: 1;
+  //flex-grow: 1;
   text-overflow: ellipsis;
-  table-layout: fixed;
+  width: fit-content;
   margin-right: 20px;
-  @media all and (max-width: 600px) {
-    display: none;
+  @media all and (max-width: 700px) {
+    width: 90%;
   }
 `;
 
 export const DateWrapper = styled.div`
+  order: 3;
   width: 120px;
   color: var(--color-textgrey);
+  @media all and (max-width: 400px) {
+    font-size: 0.8rem;
+  }
 `;
 export const Name = styled.div`
+  order: 2;
   width: 150px;
   font-weight: bold;
 `;
 export const Id = styled.div`
+  order: 1;
   width: 30px;
   color: green;
 `;
 export const Value = styled.div`
-  width: 80px;
   font-weight: bold;
+  margin-left: auto;
+  margin-right: 5px;
 
   color: green;
   text-align: right;
   & p {
     display: inline;
     margin-left: 7px;
+  }
+
+  @media all and (max-width: 700px) {
+    margin-left: unset;
   }
 `;

--- a/src/pages/Admin/ShowAllUserLogs/index.jsx
+++ b/src/pages/Admin/ShowAllUserLogs/index.jsx
@@ -5,6 +5,7 @@ import {
   ButtonWrapper,
   Card,
   Date,
+  HeaderWrapper,
   Id,
   Log,
   LogMsg,
@@ -86,11 +87,13 @@ function CurrentPage({
                 <Name>{thisUser?.notionId}</Name>
               </TextWrapper>
             </label>
-            <LogMsg>{log.description}</LogMsg>
-            <Value plus={log.changedValue >= 0} mode={mode}>
-              {log.changedValue >= 0 ? '+' : '-'}
-              {Math.abs(log.changedValue)}
-            </Value>
+            <TextWrapper>
+              <LogMsg>{log.description}</LogMsg>
+              <Value plus={log.changedValue >= 0} mode={mode}>
+                {log.changedValue >= 0 ? '+' : '-'}
+                {Math.abs(log.changedValue)}
+              </Value>
+            </TextWrapper>
           </Log>
         );
       })}
@@ -309,13 +312,19 @@ function ShowAllUserLogs() {
             </legend>
           </fieldset>
         </Title>
-        <TextWrapper>
-          {isRollback ? <div style={{ width: '20px' }}></div> : ''}
-          <div style={{ width: '50px' }}>ID</div>
-          <div style={{ width: '150px' }}>날짜</div>
-          <div style={{ width: '130px' }}>노션 아이디</div>
-          <div>사유</div>
-        </TextWrapper>
+        <Log state={true}>
+          <label>
+            <TextWrapper>
+              {isRollback ? <div style={{ width: '20px' }}></div> : ''}
+              <Id mode={mode}>ID</Id>
+              <Date>날짜</Date>
+              <Name>노션 아이디</Name>
+            </TextWrapper>
+          </label>
+          <TextWrapper>
+            <LogMsg>사유</LogMsg>
+          </TextWrapper>
+        </Log>
 
         <CurrentPage
           key={mode === 1 ? allWarningLog : allPointLog}

--- a/src/pages/Admin/ShowAllUserLogs/style.jsx
+++ b/src/pages/Admin/ShowAllUserLogs/style.jsx
@@ -37,8 +37,8 @@ export const ModeButton = styled.button`
 `;
 
 export const Value = styled.div`
-  width: 80px;
   font-weight: bold;
+  margin-right: 5px;
 
   color: ${(props) =>
     props.plus
@@ -63,26 +63,43 @@ export const LogWrapper = styled.div`
 
 export const Log = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: start;
   margin-bottom: 25px;
   width: 100%;
   text-decoration: ${(props) => (props.state ? '' : 'line-through')};
   text-decoration-color: var(--color-textgrey);
+  flex-direction: column;
+  @media (min-width: 700px) {
+    flex-direction: row;
+  }
+  @media all and (max-width: 700px) {
+    border-top: 1px solid lightgray;
+  }
+`;
+
+export const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: start;
+  width: 100%;
+  flex-direction: column;
+  @media (min-width: 700px) {
+    flex-direction: row;
+  }
 `;
 
 export const TextWrapper = styled.div`
   display: flex;
+  width: 100%;
+  margin-top: 5px;
   //flex-direction: column;
 `;
 
 export const LogMsg = styled.div`
   flex-grow: 1;
+  width: fit-content;
   text-overflow: ellipsis;
   table-layout: fixed;
   margin-right: 20px;
-  @media all and (max-width: 600px) {
-    display: none;
-  }
 `;
 
 export const Date = styled.div`

--- a/src/pages/Admin/UserManageList/UserAddDeletePage/index.jsx
+++ b/src/pages/Admin/UserManageList/UserAddDeletePage/index.jsx
@@ -7,6 +7,7 @@ import {
   Button,
   UserItem,
   Title,
+  UserDescription,
 } from './style';
 import { toast } from 'react-toastify';
 import UserAddInput from '../UserAddInput';
@@ -51,9 +52,11 @@ function UserAddDeletePage() {
       <VerticalUserListWrapper>
         {users.map((user) => (
           <UserItem key={user.notionId}>
-            <Button onClick={() => onClickUserDelete(user)}>유저 삭제</Button>
-            {user.notionId} {user.emoji} : 경고 {user.warning}회. 포인트{' '}
-            {user.point}.{' '}
+            <Button onClick={() => onClickUserDelete(user)}>삭제</Button>
+            <UserDescription>
+              {user.notionId} {user.emoji} : 경고 {user.warning}회. 포인트{' '}
+              {user.point}.{' '}
+            </UserDescription>
           </UserItem>
         ))}
       </VerticalUserListWrapper>

--- a/src/pages/Admin/UserManageList/UserAddDeletePage/style.jsx
+++ b/src/pages/Admin/UserManageList/UserAddDeletePage/style.jsx
@@ -69,16 +69,28 @@ export const Button = styled(CommonButton)`
   text-align: center;
   background-color: ${(props) => (props.isAdd ? 'green' : 'crimson')};
   color: white;
-  margin-right: 20px;
+  width: ${(props) => (props.isAdd ? '40vw' : '20vw')};
+  margin-right: 10px;
   ${(props) => {
     if (props.isAdd) {
       return 'margin-top: 20px; margin-left: 30px;';
     }
   }}
+  max-width: ${(props) => (props.isAdd ? '150px' : '80px')};
+  @media (max-width: 600px) {
+    scale: 80%;
+  }
 `;
 
 export const UserItem = styled.div`
   display: flex;
-  align-items: center;
   padding: 10px;
+`;
+
+export const UserDescription = styled.div`
+  display: flex;
+  align-items: center;
+  text-overflow: ellipsis;
+  width: 55vw;
+  margin-left: 10px;
 `;


### PR DESCRIPTION
모바일 등 너비가 좁은 환경에서의 사용성을 개선해봤습니다

![image](https://github.com/GPGT-Algorithm-Study/GPGT-Client/assets/122661764/8d92e382-dd69-4684-92a6-17f8e65eea5e)

기존에는 한 줄로 존재하다가 너비가 줄어들면 이벤트 설명이 사라지게 되어있었는데
이벤트 설명과 %를 한 줄 내려서 표시하도록 했습니다
또한 기존처럼 한 줄로 존재할 때는 구분하기 쉬웠는데
두 줄로 만들어 놓으니 구분이 좀 잘 안 되는 것 같아서 희미하게 구분선을 넣었습니다 (뷰포트가 넓은 경우 기존처럼 구분선 X)

![image](https://github.com/GPGT-Algorithm-Study/GPGT-Client/assets/122661764/8262e743-3b0e-4a40-afee-da78175caf54)

경고/포인트 로그 또한 비슷하게 변경되었습니다

![image](https://github.com/GPGT-Algorithm-Study/GPGT-Client/assets/122661764/cb315ba2-78dd-4392-8410-0284924f725c)

신규 유저 추가 / 기존 유저 삭제 화면에서
삭제 버튼과 유저 설명이 차지하는 비율이 일관적이지 못했던 점과
삭제 버튼이 모바일에서 너무 커보였던 문제를 조금 개선해봤습니다