### PR TITLE
[Design] 관리자 페이지 민원 처리 모달 디자인 변경

### DIFF
--- a/src/pages/Admin/AdminApiList/index.jsx
+++ b/src/pages/Admin/AdminApiList/index.jsx
@@ -108,7 +108,6 @@ function AdminApiList() {
         if (res.status !== 200)
           //에러 처리
           alert(res);
-        console.log(res);
         toast.success('크론 배치잡 (Every 20 min)에 성공했습니다.');
         return;
       })

--- a/src/pages/Admin/ComplaintManagement/ComplaintModal/index.jsx
+++ b/src/pages/Admin/ComplaintManagement/ComplaintModal/index.jsx
@@ -7,6 +7,26 @@ import {
   updateComplaintType,
 } from 'api/complaint';
 import { Button } from 'pages/Admin/PointEvent/DeleteEventModal/style';
+import { CommonProfileImage } from 'style/commonStyle';
+import {
+  User,
+  ComplaintWrapper,
+  Input,
+  Content,
+  ProcessType,
+  ProcessTypeWrapper,
+  DeleteButton,
+  ButtonWrapper,
+  SelectWrapper,
+  OptionWrapper,
+  ComplaintDetails,
+  RowWrapper,
+  Badge,
+  TypeBadge,
+} from './style';
+import { Complaint } from '../style';
+import { complaintProcessingType } from 'utils/complaint';
+import PageTitle from 'components/PageTitle';
 
 function getKrComplaintTypeName(complaintType) {
   if (complaintType === 'NEW_FUNCTION') return '신규 기능 건의';
@@ -25,16 +45,23 @@ function ComplaintModal(props) {
   const requesterInfo = props.requesterInfo;
   const [submitLock, setSubmitLock] = useState(false);
   const [deleteLock, setDeleteLock] = useState(false);
+  const [processTypes, setProcessTypes] = useState([
+    complaintProcessingType.WAITING,
+    complaintProcessingType.PROCESSING,
+    complaintProcessingType.DONE,
+  ]);
+  const [selectedProcessType, setSelectedProcessType] = useState(
+    complaint.processType,
+  );
 
   const onSubmit = (e) => {
     e.preventDefault();
     const processor = e.target[0].value;
-    const processType = e.target[1].value;
-    const reply = e.target[2].value;
+    const reply = e.target[1].value;
 
     const updatedComplaint = {
       id: complaint.id,
-      processType: processType,
+      processType: selectedProcessType,
       processor: processor,
       reply: reply,
     };
@@ -90,63 +117,102 @@ function ComplaintModal(props) {
   };
 
   return (
-    <div>
-      <p>
-        작성자 : {requesterInfo.emoji} {requesterInfo.notionId}
-      </p>
-      <p>ID : {complaint.id}</p>
-      <p>민원 유형 : {getKrComplaintTypeName(complaint.complaintType)}</p>
-      <p>처리 상태 : {getKrProcessTypeName(complaint.processType)}</p>
-      <p>담당자 : {complaint.processor ? complaint.processor : '-'}</p>
-      <br />
-      <p>내용</p>
-      <p style={{ whiteSpace: 'pre' }}>{complaint.content}</p>
-      <br />
-      <Button
-        style={{
-          backgroundColor: 'crimson',
-          color: 'white',
-        }}
-        onClick={onDeleteClick}
-      >
-        삭제
-      </Button>
-      <hr />
-      <p>민원 처리</p>
-      <br />
+    <ComplaintWrapper>
+      <RowWrapper>
+        <ComplaintDetails>
+          <div>
+            <b>[ID]</b> {'  '} <span>{complaint.id}</span>
+          </div>
+          <div>
+            <b>[유형]</b>
+            {'  '}
+            <span>
+              {
+                <TypeBadge type={complaint.complaintType}>
+                  {getKrComplaintTypeName(complaint.complaintType)}
+                </TypeBadge>
+              }
+            </span>
+          </div>
+          <div>
+            <b>[상태]</b>
+            {'  '}
+            <span>
+              {
+                <Badge type={complaint.processType}>
+                  {getKrProcessTypeName(complaint.processType)}
+                </Badge>
+              }
+            </span>
+          </div>
+          <div>
+            <b>[담당자]</b>
+            {'  '}
+            <span>{complaint.processor ? complaint.processor : '-'}</span>
+          </div>
+        </ComplaintDetails>
+        <User key={requesterInfo.notionId}>
+          <div>
+            {requesterInfo.notionId} {requesterInfo.emoji}
+          </div>
+          <CommonProfileImage
+            width="50"
+            height="50"
+            src={
+              requesterInfo.profileImg != 'null'
+                ? requesterInfo.profileImg
+                : 'https://static.solved.ac/misc/360x360/default_profile.png'
+            }
+            onClick={(e) => onClickProfileImg(e, requesterInfo.bojHandle)}
+            style={{ cursor: 'pointer' }}
+          ></CommonProfileImage>
+        </User>
+      </RowWrapper>
+      <PageTitle title="민원" />
+      <Content disabled={true} defaultValue={complaint.content}></Content>
+      <PageTitle title="답변" />
       <form onSubmit={(e) => onSubmit(e)}>
         <div>
-          <select
-            name="processor"
-            defaultValue={complaint.processor ? complaint.processor : ''}
-          >
-            <option value="" disabled hidden>
-              담당자 선택
-            </option>
-            <option value="seyeon0207">양세연</option>
-            <option value="fin">김성민</option>
-            <option value="asdf016182">장희영</option>
-            <option value="emforhs0315">조성훈</option>
-          </select>
+          <ProcessTypeWrapper>
+            {processTypes.map((type, index) => (
+              <ProcessType
+                key={index}
+                selected={type.key == selectedProcessType}
+                onClick={() => {
+                  setSelectedProcessType(type.key);
+                }}
+              >
+                {type.label}
+              </ProcessType>
+            ))}
+            <div>
+              <SelectWrapper
+                name="processor"
+                defaultValue={complaint.processor ? complaint.processor : ''}
+              >
+                <OptionWrapper value="" disabled hidden>
+                  담당자 선택
+                </OptionWrapper>
+                <OptionWrapper value="seyeon0207">양세연</OptionWrapper>
+                <OptionWrapper value="fin">김성민</OptionWrapper>
+                <OptionWrapper value="asdf016182">장희영</OptionWrapper>
+                <OptionWrapper value="emforhs0315">조성훈</OptionWrapper>
+              </SelectWrapper>
+            </div>
+          </ProcessTypeWrapper>
         </div>
-        <div>
-          <select name="type" defaultValue={complaint.processType}>
-            <option value="WAITING">대기중</option>
-            <option value="PROCESSING">처리중</option>
-            <option value="DONE">처리 완료</option>
-          </select>
-        </div>
-        <textarea
+        <Content
           name="reply"
           id="reply"
           placeholder="코멘트 작성.."
           defaultValue={complaint.reply}
-          style={{ width: '80%', height: '100px' }}
-        ></textarea>
-        <br />
-        <input type="submit"></input>
+        ></Content>
+        <ButtonWrapper>
+          <DeleteButton onClick={onDeleteClick}>삭제</DeleteButton>
+          <Input type="submit" value={'작성'}></Input>
+        </ButtonWrapper>
       </form>
-    </div>
+    </ComplaintWrapper>
   );
 }
 

--- a/src/pages/Admin/ComplaintManagement/ComplaintModal/style.jsx
+++ b/src/pages/Admin/ComplaintManagement/ComplaintModal/style.jsx
@@ -1,2 +1,212 @@
-import styled from '@emotion/styled';
+import styled, { css } from '@emotion/styled';
 import { CommonCard, CommonButton } from 'style/commonStyle';
+
+export const Title = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+export const ProcessTypeWrapper = styled.span`
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+`;
+
+export const FormItem = styled.div`
+  font-weight: bold;
+  & input {
+    width: ${(props) => (props.width ? props.width : '100%')};
+    border: 1px solid var(--color-unchecked);
+    padding: 1rem;
+    box-sizing: border-box;
+    border-radius: 7px;
+  }
+  & button {
+    padding: 1rem 1.1rem;
+    border: none;
+    background-color: var(--color-button-gray);
+    border-radius: 5px;
+    color: var(--color-deep-gray);
+    cursor: pointer;
+    margin-left: 10px;
+  }
+`;
+
+export const ProcessType = styled.div`
+  border-radius: 5px;
+  background-color: ${(props) =>
+    props.selected ? 'var(--color-primary)' : 'white'};
+  color: ${(props) => (props.selected ? 'white' : 'var(--color-deep-gray)')};
+  border: ${(props) =>
+    props.selected ? 'none' : '1px solid var(--color-border)'};
+  font-weight: 400;
+  cursor: pointer;
+  padding: 0.7rem 1.5rem;
+  font-size: 0.8rem;
+`;
+
+export const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  padding: 0 5px 0 5px;
+  margin-top: 2rem;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 100%;
+  height: 2.5em;
+  display: flex;
+  gap: 10px;
+  justify-content: end;
+`;
+
+export const DeleteButton = styled.div`
+  height: auto;
+  padding: 10px 20px;
+  border: none;
+  background-color: crimson;
+  border-radius: 5px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.8rem;
+`;
+
+export const Input = styled.input`
+  height: auto;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  value: ${(props) => props.value};
+`;
+
+export const Container = styled.div`
+  /* overflow: scroll; */
+  padding-bottom: 50px;
+`;
+
+export const User = styled.div`
+  width: 130px;
+  display: flex;
+  flex: 0 0 auto;
+  padding: 10px 0 10px 0;
+  flex-direction: column;
+  align-items: center;
+  font-weight: bold;
+  font: 0.9rem;
+  & div {
+    margin-bottom: 20px;
+  }
+`;
+
+export const ComplaintWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  justify-content: start;
+`;
+
+export const Content = styled.textarea`
+  width: 100%;
+  height: 150px;
+  padding: 12px 20px;
+  box-sizing: border-box;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+  background-color: #ffffff;
+  color: #000000;
+  font-size: 16px;
+  white-space: pre-wrap;
+  id: ${(props) => props.id};
+  name: ${(props) => props.name};
+  placeholder: ${(props) => props.placeholder};
+  resize: ${(props) => (props.disabled ? 'none' : 'both')};
+`;
+
+export const SelectWrapper = styled.select`
+  width: 100%;
+  padding: 10px;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+  font-weight: bold;
+  font: 0.9rem;
+  color: #000;
+  appearance: none;
+  cursor: pointer;
+
+  &:focus {
+    border-color: #007bff;
+    outline: none;
+  }
+`;
+
+export const OptionWrapper = styled.option`
+  font-size: 16px;
+  color: #000;
+  background-color: #fff;
+  padding: 10px;
+`;
+
+export const ComplaintDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+  align-items: flex-start;
+  font-size: 15px;
+
+  & > div {
+    display: flex;
+    justify-content: space-between;
+    margin: 5px 0;
+  }
+`;
+
+export const RowWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+
+export const TypeBadge = styled.span`
+  padding: 1px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  text-transform: uppercase;
+  background-color: ${(props) => {
+    switch (props.type) {
+      case 'NEW_FUNCTION':
+        return '#6666FF';
+      case 'BUG':
+        return '#CC3333';
+      case 'PROBLEM':
+        return '#FF3366';
+      default:
+        return '#999999';
+    }
+  }};
+  color: #fff; // 흰색
+`;
+
+export const Badge = styled.span`
+  padding: 1px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  text-transform: uppercase;
+  background-color: ${(props) => {
+    switch (props.type) {
+      case 'WAITING':
+        return '#999999'; // 회색
+      case 'PROCESSING':
+        return '#99CCFF'; // 남색
+      case 'DONE':
+        return '#377e22'; // 초록색
+      default:
+        return '#777'; // 회색
+    }
+  }};
+  color: #fff; // 흰색
+`;

--- a/src/pages/Admin/ComplaintManagement/index.jsx
+++ b/src/pages/Admin/ComplaintManagement/index.jsx
@@ -74,6 +74,12 @@ function ComplaintManagement() {
         <ButtonWrapper>
           <ModeButton
             onClick={() => onClickModeButton(0)}
+            selected={mode === -1}
+          >
+            전체
+          </ModeButton>
+          <ModeButton
+            onClick={() => onClickModeButton(0)}
             selected={mode === 0}
           >
             대기중

--- a/src/pages/Admin/UserSetting/index.jsx
+++ b/src/pages/Admin/UserSetting/index.jsx
@@ -86,8 +86,6 @@ function UserSetting() {
 
   if (!userSetting) return null;
 
-  console.log(userSetting);
-
   return (
     <Card>
       <Title>유저 설정</Title>

--- a/src/pages/Admin/index.jsx
+++ b/src/pages/Admin/index.jsx
@@ -13,9 +13,6 @@ import UserSetting from './UserSetting';
 import AdminApiList from './AdminApiList';
 
 function Admin() {
-  const complaint = getAllComplaint()
-    .then((res) => console.info(res))
-    .catch((e) => console.info(e));
   return (
     <div>
       <CommonFlexWrapper>

--- a/src/utils/complaint.js
+++ b/src/utils/complaint.js
@@ -1,0 +1,25 @@
+export const complaintProcessingType = {
+  WAITING: {
+    label: '대기 중',
+    key: 'WAITING',
+  },
+  PROCESSING: {
+    label: '처리 중',
+    key: 'PROCESSING',
+  },
+  DONE: {
+    label: '처리 완료',
+    key: 'DONE',
+  },
+};
+
+export function getTypeLabel(type) {
+  let label = '';
+  Object.keys(complaintProcessingType).forEach((key) => {
+    if (complaintProcessingType[key].key === type) {
+      label = complaintProcessingType[key].label;
+      return;
+    }
+  });
+  return label;
+}


### PR DESCRIPTION
### 요약
관리자 페이지의 민원 처리 모달이 CSS 디자인이 되어있지 않고, 장문의 민원의 경우 오른쪽으로 빠져나가는 문제가 있어 이를 해결

### 상세
- StyledComponent를 이용한 모달창 디자인
- 민원 관련 데이터의 가독성 향상
- 관리자페이지의 필요없는 console.log 및 API 호출 제거

### 사진
<img width="712" alt="image" src="https://github.com/GPGT-Algorithm-Study/GPGT-Client/assets/44383895/115ea5fd-e965-41c7-adcd-2cbe5562a6ec">
